### PR TITLE
add read account into trielog again

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/worldview/BonsaiWorldStateUpdateAccumulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/worldview/BonsaiWorldStateUpdateAccumulator.java
@@ -105,7 +105,7 @@ public class BonsaiWorldStateUpdateAccumulator
 
   @Override
   public Account get(final Address address) {
-    return super.get(address);
+    return super.getAccount(address);
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

I saw that we are not adding all of the read account on trielog with the current implementation https://github.com/Consensys/linea-besu/blob/zkbesu/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/worldview/BonsaiWorldStateUpdateAccumulator.java#L108 because this method is asking directly the parent https://github.com/Consensys/linea-besu/blob/zkbesu/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/worldview/BonsaiWorldState.java#L521
before we was doing like this method https://github.com/Consensys/linea-besu/blob/zkbesu/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/worldview/BonsaiWorldStateUpdateAccumulator.java#L119 and this one is adding into the cache used to create trielog https://github.com/Consensys/linea-besu/blob/zkbesu/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/worldview/BonsaiWorldStateUpdateAccumulator.java#L176 

We removed this modification https://github.com/hyperledger/besu/pull/5330 Jun 3 and delivery-1 was created https://hub.docker.com/layers/consensys/linea-besu/linea-delivery-1/images/sha256-cafcfc5d25182acf6272c4a3987e9441ffddc56082043fd971faf5185515fe12?context=explore 2023-05-10

This call is needed so I added this modification again and I will see later in order to find another way to manage that
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->