### PR TITLE
Make JsonTestParameters.generate public

### DIFF
--- a/testutil/src/main/java/org/hyperledger/besu/testutil/JsonTestParameters.java
+++ b/testutil/src/main/java/org/hyperledger/besu/testutil/JsonTestParameters.java
@@ -235,7 +235,13 @@ public class JsonTestParameters<S, T> {
     return generate(getFilteredFiles(paths));
   }
 
-  private Collection<Object[]> generate(final Collection<File> filteredFiles) {
+  /**
+   * Generate collection.
+   *
+   * @param filteredFiles the filtered files
+   * @return the collection
+   */
+  public Collection<Object[]> generate(final Collection<File> filteredFiles) {
     checkState(generator != null, "Missing generator function");
 
     final Collector<T> collector =


### PR DESCRIPTION
Making this method public allows to use it in reference tests