### PR TITLE
Split workflow so that publishing only happens when PR is merged

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -9,7 +9,7 @@ on:
       - zkbesu
 
 jobs:
-  all:
+  build_and_test:
     runs-on: ubuntu-22.04-16core
     env:
       architecture: "amd64"
@@ -51,6 +51,24 @@ jobs:
           reporter: java-junit        # Format of test results
           only-summary: true
           max-annotations: 50
+
+  publish:
+    needs: build_and_test
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-22.04-16core
+    env:
+      architecture: "amd64"
+      GRADLE_OPTS: "-Xmx6g -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'adopt'
 
       - name: Publish Java artifacts
         run: ./gradlew publish


### PR DESCRIPTION
Artefacts should be only published when PRs are merged