### PR TITLE
Revert to using bonsai accumulator behavior in main

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/bonsai/worldview/BonsaiWorldStateUpdateAccumulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/bonsai/worldview/BonsaiWorldStateUpdateAccumulator.java
@@ -109,7 +109,7 @@ public class BonsaiWorldStateUpdateAccumulator
 
   @Override
   public Account get(final Address address) {
-    return super.getAccount(address);
+    return super.get(address);
   }
 
   @Override


### PR DESCRIPTION
Revert to using super.get() in BonsaiWorldStateUpdateAccumulator, as in [hyperledger/besu](https://github.com/hyperledger/besu/blob/main/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/bonsai/worldview/BonsaiWorldStateUpdateAccumulator.java#L112)