### PR TITLE
Introduce TransactionSelectionContext to pass data between selectors and plugin

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -412,8 +412,7 @@ public class BlockTransactionSelector {
           evaluationContext, timeoutSelectionResult, txWorldStateUpdater);
     }
 
-    pluginTransactionSelector.onTransactionSelected(
-        evaluationContext.getPendingTransaction(), processingResult);
+    pluginTransactionSelector.onTransactionSelected(evaluationContext, processingResult);
     blockWorldStateUpdater = worldState.updater();
     LOG.atTrace()
         .setMessage("Selected {} for block creation, evaluated in {}")
@@ -440,7 +439,7 @@ public class BlockTransactionSelector {
 
     transactionSelectionResults.updateNotSelected(
         evaluationContext.getTransaction(), selectionResult);
-    pluginTransactionSelector.onTransactionNotSelected(pendingTransaction, selectionResult);
+    pluginTransactionSelector.onTransactionNotSelected(evaluationContext, selectionResult);
     LOG.atTrace()
         .setMessage("Not selected {} for block creation with result {}, evaluated in {}")
         .addArgument(pendingTransaction::toTraceLog)

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -228,26 +228,42 @@ public class BlockTransactionSelector {
       final PendingTransaction pendingTransaction) {
     checkCancellation();
 
-    final Stopwatch evaluationTimer = Stopwatch.createStarted();
+    final TransactionEvaluationContext evaluationContext =
+        createTransactionEvaluationContext(pendingTransaction);
 
-    TransactionSelectionResult selectionResult = evaluatePreProcessing(pendingTransaction);
+    TransactionSelectionResult selectionResult = evaluatePreProcessing(evaluationContext);
     if (!selectionResult.selected()) {
-      return handleTransactionNotSelected(pendingTransaction, selectionResult, evaluationTimer);
+      return handleTransactionNotSelected(evaluationContext, selectionResult);
     }
 
     final WorldUpdater txWorldStateUpdater = blockWorldStateUpdater.updater();
     final TransactionProcessingResult processingResult =
         processTransaction(pendingTransaction, txWorldStateUpdater);
 
-    var postProcessingSelectionResult =
-        evaluatePostProcessing(pendingTransaction, processingResult);
+    var postProcessingSelectionResult = evaluatePostProcessing(evaluationContext, processingResult);
 
     if (postProcessingSelectionResult.selected()) {
-      return handleTransactionSelected(
-          pendingTransaction, processingResult, txWorldStateUpdater, evaluationTimer);
+      return handleTransactionSelected(evaluationContext, processingResult, txWorldStateUpdater);
     }
     return handleTransactionNotSelected(
-        pendingTransaction, postProcessingSelectionResult, txWorldStateUpdater, evaluationTimer);
+        evaluationContext, postProcessingSelectionResult, txWorldStateUpdater);
+  }
+
+  private TransactionEvaluationContext createTransactionEvaluationContext(
+      final PendingTransaction pendingTransaction) {
+    final Wei transactionGasPriceInBlock =
+        blockSelectionContext
+            .feeMarket()
+            .getTransactionPriceCalculator()
+            .price(
+                pendingTransaction.getTransaction(),
+                blockSelectionContext.processableBlockHeader().getBaseFee());
+
+    return new TransactionEvaluationContext(
+        pendingTransaction,
+        Stopwatch.createStarted(),
+        transactionGasPriceInBlock,
+        blockSelectionContext.miningParameters().getMinTransactionGasPrice());
   }
 
   /**
@@ -256,21 +272,20 @@ public class BlockTransactionSelector {
    * it then processes it through external selectors. If the transaction is selected by all
    * selectors, it returns SELECTED.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection session data.
    * @return The result of the transaction selection process.
    */
   private TransactionSelectionResult evaluatePreProcessing(
-      final PendingTransaction pendingTransaction) {
+      final TransactionEvaluationContext evaluationContext) {
 
     for (var selector : transactionSelectors) {
       TransactionSelectionResult result =
-          selector.evaluateTransactionPreProcessing(
-              pendingTransaction, transactionSelectionResults);
+          selector.evaluateTransactionPreProcessing(evaluationContext, transactionSelectionResults);
       if (!result.equals(SELECTED)) {
         return result;
       }
     }
-    return pluginTransactionSelector.evaluateTransactionPreProcessing(pendingTransaction);
+    return pluginTransactionSelector.evaluateTransactionPreProcessing(evaluationContext);
   }
 
   /**
@@ -279,24 +294,24 @@ public class BlockTransactionSelector {
    * whether the transaction should be included in a block. If the transaction is selected by all
    * selectors, it returns SELECTED.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection session data.
    * @param processingResult The result of the transaction processing.
    * @return The result of the transaction selection process.
    */
   private TransactionSelectionResult evaluatePostProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionProcessingResult processingResult) {
 
     for (var selector : transactionSelectors) {
       TransactionSelectionResult result =
           selector.evaluateTransactionPostProcessing(
-              pendingTransaction, transactionSelectionResults, processingResult);
+              evaluationContext, transactionSelectionResults, processingResult);
       if (!result.equals(SELECTED)) {
         return result;
       }
     }
     return pluginTransactionSelector.evaluateTransactionPostProcessing(
-        pendingTransaction, processingResult);
+        evaluationContext, processingResult);
   }
 
   /**
@@ -328,18 +343,16 @@ public class BlockTransactionSelector {
    * receipt, updating the TransactionSelectionResults with the selected transaction, and notifying
    * the external transaction selector.
    *
-   * @param pendingTransaction The pending transaction.
+   * @param evaluationContext The current selection session data.
    * @param processingResult The result of the transaction processing.
    * @param txWorldStateUpdater The world state updater.
-   * @param evaluationTimer tracks the evaluation elapsed time
    * @return The result of the transaction selection process.
    */
   private TransactionSelectionResult handleTransactionSelected(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionProcessingResult processingResult,
-      final WorldUpdater txWorldStateUpdater,
-      final Stopwatch evaluationTimer) {
-    final Transaction transaction = pendingTransaction.getTransaction();
+      final WorldUpdater txWorldStateUpdater) {
+    final Transaction transaction = evaluationContext.getTransaction();
 
     final long gasUsedByTransaction =
         transaction.getGasLimit() - processingResult.getGasRemaining();
@@ -363,13 +376,14 @@ public class BlockTransactionSelector {
                 transaction.getType(), processingResult, worldState, cumulativeGasUsed);
 
         transactionSelectionResults.updateSelected(
-            pendingTransaction.getTransaction(), receipt, gasUsedByTransaction, blobGasUsed);
+            transaction, receipt, gasUsedByTransaction, blobGasUsed);
       }
     }
 
     if (tooLate) {
       // even if this tx passed all the checks, it is too late to include it in this block,
       // so we need to treat it as not selected
+      final var evaluationTimer = evaluationContext.getEvaluationTimer();
 
       // check if this tx took too much to evaluate, and in case remove it from the pool
       final TransactionSelectionResult timeoutSelectionResult;
@@ -395,15 +409,16 @@ public class BlockTransactionSelector {
       // do not rely on the presence of this result, since by the time it is added, the code
       // reading it could have been already executed by another thread
       return handleTransactionNotSelected(
-          pendingTransaction, timeoutSelectionResult, txWorldStateUpdater, evaluationTimer);
+          evaluationContext, timeoutSelectionResult, txWorldStateUpdater);
     }
 
-    pluginTransactionSelector.onTransactionSelected(pendingTransaction, processingResult);
+    pluginTransactionSelector.onTransactionSelected(
+        evaluationContext.getPendingTransaction(), processingResult);
     blockWorldStateUpdater = worldState.updater();
     LOG.atTrace()
         .setMessage("Selected {} for block creation, evaluated in {}")
         .addArgument(transaction::toTraceLog)
-        .addArgument(evaluationTimer)
+        .addArgument(evaluationContext.getPendingTransaction())
         .log();
     return SELECTED;
   }
@@ -413,36 +428,35 @@ public class BlockTransactionSelector {
    * TransactionSelectionResults with the unselected transaction, and notifies the external
    * transaction selector.
    *
-   * @param pendingTransaction The unselected pending transaction.
+   * @param evaluationContext The current selection session data.
    * @param selectionResult The result of the transaction selection process.
-   * @param evaluationTimer tracks the evaluation elapsed time
    * @return The result of the transaction selection process.
    */
   private TransactionSelectionResult handleTransactionNotSelected(
-      final PendingTransaction pendingTransaction,
-      final TransactionSelectionResult selectionResult,
-      final Stopwatch evaluationTimer) {
+      final TransactionEvaluationContext evaluationContext,
+      final TransactionSelectionResult selectionResult) {
+
+    final var pendingTransaction = evaluationContext.getPendingTransaction();
 
     transactionSelectionResults.updateNotSelected(
-        pendingTransaction.getTransaction(), selectionResult);
+        evaluationContext.getTransaction(), selectionResult);
     pluginTransactionSelector.onTransactionNotSelected(pendingTransaction, selectionResult);
     LOG.atTrace()
         .setMessage("Not selected {} for block creation with result {}, evaluated in {}")
         .addArgument(pendingTransaction::toTraceLog)
         .addArgument(selectionResult)
-        .addArgument(evaluationTimer)
+        .addArgument(evaluationContext.getEvaluationTimer())
         .log();
 
     return selectionResult;
   }
 
   private TransactionSelectionResult handleTransactionNotSelected(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResult selectionResult,
-      final WorldUpdater txWorldStateUpdater,
-      final Stopwatch evaluationTimer) {
+      final WorldUpdater txWorldStateUpdater) {
     txWorldStateUpdater.revert();
-    return handleTransactionNotSelected(pendingTransaction, selectionResult, evaluationTimer);
+    return handleTransactionNotSelected(evaluationContext, selectionResult);
   }
 
   private void checkCancellation() {

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/TransactionEvaluationContext.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/TransactionEvaluationContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.blockcreation.txselection;
+
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+
+import com.google.common.base.Stopwatch;
+
+public class TransactionEvaluationContext
+    implements org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext<
+        PendingTransaction> {
+  private final org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction
+      pendingTransaction;
+  private final Stopwatch evaluationTimer;
+  private final Wei transactionGasPrice;
+  private final Wei minGasPrice;
+
+  public TransactionEvaluationContext(
+      final PendingTransaction pendingTransaction,
+      final Stopwatch evaluationTimer,
+      final Wei transactionGasPrice,
+      final Wei minGasPrice) {
+    this.pendingTransaction = pendingTransaction;
+    this.evaluationTimer = evaluationTimer;
+    this.transactionGasPrice = transactionGasPrice;
+    this.minGasPrice = minGasPrice;
+  }
+
+  public Transaction getTransaction() {
+    return pendingTransaction.getTransaction();
+  }
+
+  @Override
+  public PendingTransaction getPendingTransaction() {
+    return pendingTransaction;
+  }
+
+  @Override
+  public Stopwatch getEvaluationTimer() {
+    return evaluationTimer;
+  }
+
+  @Override
+  public Wei getTransactionGasPrice() {
+    return transactionGasPrice;
+  }
+
+  @Override
+  public Wei getMinGasPrice() {
+    return minGasPrice;
+  }
+}

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/AbstractTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/AbstractTransactionSelector.java
@@ -15,8 +15,8 @@
 package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 
 import org.hyperledger.besu.ethereum.blockcreation.txselection.BlockSelectionContext;
+import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionEvaluationContext;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionSelectionResults;
-import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 
@@ -34,25 +34,25 @@ public abstract class AbstractTransactionSelector {
   /**
    * Evaluates a transaction in the context of other transactions in the same block.
    *
-   * @param pendingTransaction The transaction to be evaluated within a block.
+   * @param evaluationContext The current selection session data.
    * @param blockTransactionResults The results of other transaction evaluations in the same block.
    * @return The result of the transaction evaluation
    */
   public abstract TransactionSelectionResult evaluateTransactionPreProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults blockTransactionResults);
 
   /**
    * Evaluates a transaction considering other transactions in the same block and a transaction
    * processing result.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection session data.
    * @param blockTransactionResults The results of other transaction evaluations in the same block.
    * @param processingResult The result of transaction processing.
    * @return The result of the transaction evaluation
    */
   public abstract TransactionSelectionResult evaluateTransactionPostProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults blockTransactionResults,
       final TransactionProcessingResult processingResult);
 }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/AllAcceptingTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/AllAcceptingTransactionSelector.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
+import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
 
 /** A TransactionSelector that unconditionally selects all transactions. */
 public class AllAcceptingTransactionSelector implements PluginTransactionSelector {
@@ -29,25 +30,25 @@ public class AllAcceptingTransactionSelector implements PluginTransactionSelecto
   /**
    * Always selects the transaction in the pre-processing stage.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection context.
    * @return Always SELECTED.
    */
   @Override
   public TransactionSelectionResult evaluateTransactionPreProcessing(
-      final PendingTransaction pendingTransaction) {
+      final TransactionEvaluationContext<? extends PendingTransaction> evaluationContext) {
     return TransactionSelectionResult.SELECTED;
   }
 
   /**
    * Always selects the transaction in the post-processing stage.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection context.
    * @param processingResult The result of the transaction processing.
    * @return Always SELECTED.
    */
   @Override
   public TransactionSelectionResult evaluateTransactionPostProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext<? extends PendingTransaction> evaluationContext,
       final TransactionProcessingResult processingResult) {
     return TransactionSelectionResult.SELECTED;
   }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlobPriceTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlobPriceTransactionSelector.java
@@ -15,9 +15,9 @@
 package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 
 import org.hyperledger.besu.ethereum.blockcreation.txselection.BlockSelectionContext;
+import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionEvaluationContext;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionSelectionResults;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 
@@ -39,14 +39,15 @@ public class BlobPriceTransactionSelector extends AbstractTransactionSelector {
   /**
    * Evaluates a transaction considering its blob price.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection session data.
    * @param ignored The results of other transaction evaluations in the same block.
    * @return The result of the transaction selection.
    */
   @Override
   public TransactionSelectionResult evaluateTransactionPreProcessing(
-      final PendingTransaction pendingTransaction, final TransactionSelectionResults ignored) {
-    if (transactionBlobPriceBelowMin(pendingTransaction.getTransaction())) {
+      final TransactionEvaluationContext evaluationContext,
+      final TransactionSelectionResults ignored) {
+    if (transactionBlobPriceBelowMin(evaluationContext.getTransaction())) {
       return TransactionSelectionResult.BLOB_PRICE_BELOW_CURRENT_MIN;
     }
     return TransactionSelectionResult.SELECTED;
@@ -54,7 +55,7 @@ public class BlobPriceTransactionSelector extends AbstractTransactionSelector {
 
   @Override
   public TransactionSelectionResult evaluateTransactionPostProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults blockTransactionResults,
       final TransactionProcessingResult processingResult) {
     // All necessary checks were done in the pre-processing method, so nothing to do here.

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelector.java
@@ -15,9 +15,9 @@
 package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 
 import org.hyperledger.besu.ethereum.blockcreation.txselection.BlockSelectionContext;
+import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionEvaluationContext;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionSelectionResults;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 
@@ -40,20 +40,21 @@ public class BlockSizeTransactionSelector extends AbstractTransactionSelector {
    * Evaluates a transaction considering other transactions in the same block. If the transaction is
    * too large for the block returns a selection result based on block occupancy.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection session data.
    * @param transactionSelectionResults The results of other transaction evaluations in the same
    *     block.
    * @return The result of the transaction selection.
    */
   @Override
   public TransactionSelectionResult evaluateTransactionPreProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults transactionSelectionResults) {
+
     if (transactionTooLargeForBlock(
-        pendingTransaction.getTransaction(), transactionSelectionResults)) {
+        evaluationContext.getTransaction(), transactionSelectionResults)) {
       LOG.atTrace()
           .setMessage("Transaction {} too large to select for block creation")
-          .addArgument(pendingTransaction::toTraceLog)
+          .addArgument(evaluationContext.getPendingTransaction()::toTraceLog)
           .log();
       if (blockOccupancyAboveThreshold(transactionSelectionResults)) {
         LOG.trace("Block occupancy above threshold, completing operation");
@@ -70,7 +71,7 @@ public class BlockSizeTransactionSelector extends AbstractTransactionSelector {
 
   @Override
   public TransactionSelectionResult evaluateTransactionPostProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults blockTransactionResults,
       final TransactionProcessingResult processingResult) {
     // All necessary checks were done in the pre-processing method, so nothing to do here.

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/MinPriorityFeePerGasTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/MinPriorityFeePerGasTransactionSelector.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.BlockSelectionContext;
+import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionEvaluationContext;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionSelectionResults;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
@@ -36,7 +37,7 @@ public class MinPriorityFeePerGasTransactionSelector extends AbstractTransaction
   /**
    * Evaluates a transaction before processing.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection session data.
    * @param transactionSelectionResults The results of other transaction evaluations in the same
    *     block.
    * @return TransactionSelectionResult. If the priority fee is below the minimum, it returns an
@@ -44,9 +45,9 @@ public class MinPriorityFeePerGasTransactionSelector extends AbstractTransaction
    */
   @Override
   public TransactionSelectionResult evaluateTransactionPreProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults transactionSelectionResults) {
-    if (isPriorityFeePriceBelowMinimum(pendingTransaction)) {
+    if (isPriorityFeePriceBelowMinimum(evaluationContext.getPendingTransaction())) {
       return TransactionSelectionResult.PRIORITY_FEE_PER_GAS_BELOW_CURRENT_MIN;
     }
     return TransactionSelectionResult.SELECTED;
@@ -74,13 +75,13 @@ public class MinPriorityFeePerGasTransactionSelector extends AbstractTransaction
   /**
    * No evaluation is performed post-processing.
    *
-   * @param pendingTransaction The processed transaction.
+   * @param evaluationContext The current selection session data.
    * @param processingResult The result of the transaction processing.
    * @return Always returns SELECTED.
    */
   @Override
   public TransactionSelectionResult evaluateTransactionPostProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults blockTransactionResults,
       final TransactionProcessingResult processingResult) {
     return TransactionSelectionResult.SELECTED;

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/ProcessingResultTransactionSelector.java
@@ -15,9 +15,9 @@
 package org.hyperledger.besu.ethereum.blockcreation.txselection.selectors;
 
 import org.hyperledger.besu.ethereum.blockcreation.txselection.BlockSelectionContext;
+import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionEvaluationContext;
 import org.hyperledger.besu.ethereum.blockcreation.txselection.TransactionSelectionResults;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
@@ -41,7 +41,7 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
 
   @Override
   public TransactionSelectionResult evaluateTransactionPreProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults blockTransactionResults) {
     // All checks depend on processingResult and will be done in the post-processing method, so
     // nothing to do here.
@@ -53,20 +53,20 @@ public class ProcessingResultTransactionSelector extends AbstractTransactionSele
    * result. If the processing result is invalid, it determines the selection result for the invalid
    * result.
    *
-   * @param pendingTransaction The transaction to be evaluated.
+   * @param evaluationContext The current selection session data.
    * @param blockTransactionResults The results of other transaction evaluations in the same block.
    * @param processingResult The processing result of the transaction.
    * @return The result of the transaction selection.
    */
   @Override
   public TransactionSelectionResult evaluateTransactionPostProcessing(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext evaluationContext,
       final TransactionSelectionResults blockTransactionResults,
       final TransactionProcessingResult processingResult) {
 
     if (processingResult.isInvalid()) {
       return transactionSelectionResultForInvalidResult(
-          pendingTransaction.getTransaction(), processingResult.getValidationResult());
+          evaluationContext.getTransaction(), processingResult.getValidationResult());
     }
     return TransactionSelectionResult.SELECTED;
   }

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
@@ -726,13 +726,14 @@ public abstract class AbstractBlockTransactionSelectorTest {
 
     selector.buildTransactionListForBlock();
 
-    ArgumentCaptor<PendingTransaction> argumentCaptor =
-        ArgumentCaptor.forClass(PendingTransaction.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<TransactionEvaluationContext<PendingTransaction>> argumentCaptor =
+        ArgumentCaptor.forClass(TransactionEvaluationContext.class);
 
     // selected transaction must be notified to the selector
     verify(transactionSelector)
         .onTransactionSelected(argumentCaptor.capture(), any(TransactionProcessingResult.class));
-    PendingTransaction selected = argumentCaptor.getValue();
+    PendingTransaction selected = argumentCaptor.getValue().getPendingTransaction();
     assertThat(selected.getTransaction()).isEqualTo(transaction);
 
     // unselected transaction must be notified to the selector with correct reason
@@ -740,7 +741,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
         .onTransactionNotSelected(
             argumentCaptor.capture(),
             eq(TransactionSelectionResult.invalid(invalidReason.toString())));
-    PendingTransaction rejectedTransaction = argumentCaptor.getValue();
+    PendingTransaction rejectedTransaction = argumentCaptor.getValue().getPendingTransaction();
     assertThat(rejectedTransaction.getTransaction()).isEqualTo(invalidTransaction);
   }
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -69,7 +69,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'N583pqJipDs4kJkgL0cPq9PBsYdsLzvUlu2I8Kk+w7g='
+  knownHash = 'huR8kAtuiOvjy2384yFZh4PI971rEH14QMjnra3aWTE='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -69,7 +69,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'huR8kAtuiOvjy2384yFZh4PI971rEH14QMjnra3aWTE='
+  knownHash = 'IGq+V3KaStHCRFkeK3KwPxJYKO4RX9YM1O4JYITk8S8='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/PluginTransactionSelector.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/PluginTransactionSelector.java
@@ -60,19 +60,19 @@ public interface PluginTransactionSelector {
   /**
    * Method called when a transaction is selected to be added to a block.
    *
-   * @param pendingTransaction The transaction that has been selected.
+   * @param evaluationContext The current selection context
    * @param processingResult The result of processing the selected transaction.
    */
   default void onTransactionSelected(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext<? extends PendingTransaction> evaluationContext,
       final TransactionProcessingResult processingResult) {}
   /**
    * Method called when a transaction is not selected to be added to a block.
    *
-   * @param pendingTransaction The transaction that has not been selected.
+   * @param evaluationContext The current selection context
    * @param transactionSelectionResult The transaction selection result
    */
   default void onTransactionNotSelected(
-      final PendingTransaction pendingTransaction,
+      final TransactionEvaluationContext<? extends PendingTransaction> evaluationContext,
       final TransactionSelectionResult transactionSelectionResult) {}
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/PluginTransactionSelector.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/PluginTransactionSelector.java
@@ -39,22 +39,23 @@ public interface PluginTransactionSelector {
    * Method called to decide whether a transaction is added to a block. The result can also indicate
    * that no further transactions can be added to the block.
    *
-   * @param pendingTransaction candidate transaction
+   * @param evaluationContext The current selection context
    * @return TransactionSelectionResult that indicates whether to include the transaction
    */
   TransactionSelectionResult evaluateTransactionPreProcessing(
-      PendingTransaction pendingTransaction);
+      TransactionEvaluationContext<? extends PendingTransaction> evaluationContext);
 
   /**
    * Method called to decide whether a processed transaction is added to a block. The result can
    * also indicate that no further transactions can be added to the block.
    *
-   * @param pendingTransaction candidate transaction
+   * @param evaluationContext The current selection context
    * @param processingResult the transaction processing result
    * @return TransactionSelectionResult that indicates whether to include the transaction
    */
   TransactionSelectionResult evaluateTransactionPostProcessing(
-      PendingTransaction pendingTransaction, TransactionProcessingResult processingResult);
+      TransactionEvaluationContext<? extends PendingTransaction> evaluationContext,
+      TransactionProcessingResult processingResult);
 
   /**
    * Method called when a transaction is selected to be added to a block.

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/TransactionEvaluationContext.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/TransactionEvaluationContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.plugin.services.txselection;
+
+import org.hyperledger.besu.datatypes.PendingTransaction;
+import org.hyperledger.besu.datatypes.Wei;
+
+import com.google.common.base.Stopwatch;
+
+/**
+ * This interface defines the context for evaluating a transaction. It provides methods to get the
+ * pending transaction, the evaluation timer, and the transaction gas price.
+ *
+ * @param <PT> the type of the pending transaction
+ */
+public interface TransactionEvaluationContext<PT extends PendingTransaction> {
+
+  /**
+   * Gets the pending transaction.
+   *
+   * @return the pending transaction
+   */
+  PT getPendingTransaction();
+
+  /**
+   * Gets the stopwatch used for timing the evaluation.
+   *
+   * @return the evaluation timer
+   */
+  Stopwatch getEvaluationTimer();
+
+  /**
+   * Gets the gas price of the transaction.
+   *
+   * @return the transaction gas price
+   */
+  Wei getTransactionGasPrice();
+
+  /**
+   * Gets the min gas price for block inclusion
+   *
+   * @return the min gas price
+   */
+  Wei getMinGasPrice();
+}


### PR DESCRIPTION
Some tx selector plugins needs more context about the current tx being evaluated, for example the current minGasPrice, or the effective price of the tx and possibly more data in the future, for this we introduce the `TransactionSelectionContext` to hold that data and pass it across all the selectors and the plugin. Another advantage of this context is to avoid to compute multiple time the same data, in case it is needed in more that one selector.

This PR will be ported to main Besu repo as well.